### PR TITLE
Fixed the existing instance being deleted in Awake

### DIFF
--- a/Runtime/Scripts/MonoSingleton.cs
+++ b/Runtime/Scripts/MonoSingleton.cs
@@ -72,7 +72,7 @@ namespace UnityCommunity.UnitySingleton
                 // Initialize existing instance
                 InitializeSingleton();
             }
-            else
+            else if (instance != this)
             {
 
                 // Destory duplicates


### PR DESCRIPTION
Replaced `else` with `else if (instance != this)` as a condition for the instance to be deleted in Awake.
This fixes a really weird bug where if singleton was used in the editor and then again in play mode, it would delete the original instance and create a new one.
Closes #21