### PR TITLE
Added [DefaultExecutionOrder(-50)] to MonoSingleton

### DIFF
--- a/Runtime/Scripts/MonoSingleton.cs
+++ b/Runtime/Scripts/MonoSingleton.cs
@@ -6,6 +6,7 @@ namespace UnityCommunity.UnitySingleton
     /// The basic MonoBehaviour singleton implementation, this singleton is destroyed after scene changes, use <see cref="PersistentMonoSingleton{T}"/> if you want a persistent and global singleton instance.
     /// </summary>
     /// <typeparam name="T"></typeparam>
+    [DefaultExecutionOrder(-50)]
     public abstract class MonoSingleton<T> : MonoBehaviour, ISingleton where T : MonoSingleton<T>
     {
         #region Fields


### PR DESCRIPTION
Afaik, this causes no harm and ensures the singleton functions(such as Awake, Update etc.) are executed before other classes. This can be changed in inherited classes if needed, but in 99% of the cases, I would say that you'd want the singleton to execute first. -50 seemed like a reasonable choice due to certain built in classes utilizing up to -100(e.g. UnityEngine.InputSystem.PlayerInput) and this way we still get plenty of free room around the singleton.