### PR TITLE
HasInstance boolean for unsubscribing from events in OnDisable/OnDestroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Add `using UnityCommunity.UnitySingleton;` for using the classes.
 ## Common Issues
 
 1. "Some objects were not cleaned up when closing the scene. (Did you spawn new GameObjects from OnDestroy?)"
-	This issue is caused when trying to unsubscribe from an event in OnDestroy/OnDisable. It happens because the singleton is destroyed before trying to unsubscribe, and because no singleton exists it tries to spawn a new one. It spawns this new singleton as the scene is getting disabled, producing this error.
+	This issue is caused when trying to unsubscribe from an event in OnDestroy/OnDisable. It happens because the singleton is destroyed before trying to unsubscribe, which spawns a new one as the scene is getting disabled, producing this error.
 	
-	To fix this error, check the `<T>.HasInstance` bool on the singleton in an if statement before unsubscribing the events.
+	To fix this error, check the `<T>.HasInstance` bool on the singleton in an if statement before unsubscribing from events.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ Add `using UnityCommunity.UnitySingleton;` for using the classes.
 - Use `MonoSingleton<T>` if you want a Scene-based singleton which is not persistent across scenes.
 - Use `PersistentMonoSingleton<T>` if you want a Global and persistent singleton across scenes.
 
+## Common Issues
+
+1. "Some objects were not cleaned up when closing the scene. (Did you spawn new GameObjects from OnDestroy?)"
+	This issue is caused when trying to unsubscribe from an event in OnDestroy/OnDisable. It happens because the singleton is destroyed before trying to unsubscribe, and because no singleton exists it tries to spawn a new one. It spawns this new singleton as the scene is getting disabled, producing this error.
+	
+	To fix this error, check the `<T>.HasInstance` bool on the singleton in an if statement before unsubscribing the events.
+
 ## Contribute
 
 Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to contribute to this project.

--- a/Runtime/Scripts/MonoSingleton.cs
+++ b/Runtime/Scripts/MonoSingleton.cs
@@ -51,6 +51,11 @@ namespace UnityCommunity.UnitySingleton
                 return instance;
             }
         }
+        
+        /// <summary>
+        /// Gets whether an instance of this singleton exists.
+        /// </summary>
+        public static bool HasInstance => instance != null;
 
         /// <summary>
         /// Gets whether the singleton's instance is initialized.

--- a/Runtime/Scripts/Singleton.cs
+++ b/Runtime/Scripts/Singleton.cs
@@ -56,6 +56,11 @@
         }
 
         /// <summary>
+        /// Gets whether an instance of this singleton exists.
+        /// </summary>
+        public static bool HasInstance => instance != null;
+
+        /// <summary>
         /// Gets whether the singleton's instance is initialized.
         /// </summary>
         public virtual bool IsInitialized => this.initializationStatus == SingletonInitializationStatus.Initialized;


### PR DESCRIPTION
Fixes the issue brought up in #17 

## Changes
- Added a `HasInstance` boolean in the `MonoSingleton<T>` and `Singleton<T>` scripts.
- Updated the `README.md` with a "Common Issues" section which lists why this error happens, and how to fix it


I ran into this error when making my own game using this package and trying to unsubscribe from events. I tried the fix described in the response and it worked, but I saw there was no fix in the project for it. I would have to add it to every script I made if I didn't fix it, so here we are.